### PR TITLE
bucket selector query creation support es1.4

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.AbstractPipelineAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.facet.FacetBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
@@ -637,6 +638,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
      */
     public SearchRequestBuilder setAggregations(Map aggregations) {
         sourceBuilder().aggregations(aggregations);
+        return this;
+    }
+
+    public SearchRequestBuilder addAggregation(AbstractPipelineAggregationBuilder aggregation) {
+        sourceBuilder().aggregation(aggregation);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.DoubleArrayList;
 import com.carrotsearch.hppc.FloatArrayList;
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.ObjectArrayList;
+import com.google.common.collect.Maps;
 import org.apache.lucene.util.*;
 import org.elasticsearch.common.Preconditions;
 
@@ -357,5 +358,33 @@ public enum CollectionUtils {
 
     }
 
+    public static <T, S> boolean isNotEmpty(Map<T, S> map) {
+        return !isEmpty(map);
+    }
 
+    public static <T, S> boolean isEmpty(Map<T, S> map) {
+        return map == null || map.isEmpty();
+    }
+
+    public static <T> boolean isNotEmpty(Collection<T> collection) {
+        return !isEmpty(collection);
+    }
+
+    public static <T> boolean isEmpty(Collection<T> collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    public static <T, S> Map<T, S> nullSafeMap(Map<T, S> map) {
+        if (map == null) {
+            return Maps.newHashMap();
+        }
+        return map;
+    }
+
+    public static <T, S> Map<T, S> emptyIfNull(Map<T, S> map) {
+        if (map == null) {
+            return Collections.emptyMap();
+        }
+        return map;
+    }
 }

--- a/src/main/java/org/elasticsearch/script/Script.java
+++ b/src/main/java/org/elasticsearch/script/Script.java
@@ -1,0 +1,158 @@
+package org.elasticsearch.script;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.script.ScriptService.ScriptType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.util.CollectionUtils.emptyIfNull;
+
+/**
+ * @author sudeep
+ * @since 15/07/17
+ */
+public class Script implements ToXContent {
+
+    public static final String DEFAULT_SCRIPT_LANG = "mvel";
+    public static final ScriptType DEFAULT_SCRIPT_TYPE = ScriptType.INLINE;
+
+    /**
+     * Standard {@link ParseField} for outer level of script queries.
+     */
+    public static final ParseField SCRIPT_PARSE_FIELD = new ParseField("script");
+
+    /**
+     * Standard {@link ParseField} for lang on the inner level.
+     */
+    public static final ParseField LANG_PARSE_FIELD = new ParseField("lang");
+
+    /**
+     * Standard {@link ParseField} for options on the inner level.
+     */
+    public static final ParseField OPTIONS_PARSE_FIELD = new ParseField("options");
+
+    /**
+     * Standard {@link ParseField} for params on the inner level.
+     */
+    public static final ParseField PARAMS_PARSE_FIELD = new ParseField("params");
+
+
+    private final ScriptType type;
+    private final String lang;
+    private final String idOrCode;
+    private final Map<String, String> options;
+    private final Map<String, Object> params;
+
+    /**
+     * Constructor for simple script using the default language and default type.
+     *
+     * @param idOrCode The id or code to use dependent on the default script type.
+     */
+    public Script(String idOrCode) {
+        this(DEFAULT_SCRIPT_TYPE, DEFAULT_SCRIPT_LANG, idOrCode, Collections.<String, String>emptyMap(), Collections.<String, Object>emptyMap());
+    }
+
+    public Script(String idOrCode, Map<String, Object> params) {
+        this(DEFAULT_SCRIPT_TYPE, DEFAULT_SCRIPT_LANG, idOrCode, params);
+    }
+
+    public Script(ScriptType type, String lang, String idOrCode, Map<String, Object> params) {
+        this(type, lang, idOrCode, Collections.<String, String>emptyMap(), params);
+    }
+
+    public Script(ScriptType type, String lang, String idOrCode, Map<String, String> options, Map<String, Object> params) {
+        this.type = Objects.requireNonNull(type);
+        this.idOrCode = Objects.requireNonNull(idOrCode);
+        this.params = Collections.unmodifiableMap(emptyIfNull(params));
+        this.lang = lang;
+        this.options = Collections.unmodifiableMap(emptyIfNull(options));
+    }
+
+    public ScriptType getType() {
+        return type;
+    }
+
+    public String getLang() {
+        return lang;
+    }
+
+    public String getIdOrCode() {
+        return idOrCode;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (ToXContentUtils.getVersionFromParams(params).onOrAfter(Version.V_5_0_0)) {
+            builder.field(type.lowerCaseName(), idOrCode);
+        } else if (ScriptType.INDEXED.equals(type)) {
+            builder.field(ScriptService.SCRIPT_ID.getPreferredName(), idOrCode);
+        } else if (ScriptType.FILE.equals(type)) {
+            builder.field(ScriptService.SCRIPT_FILE.getPreferredName(), idOrCode);
+        } else if (ScriptType.INLINE.equals(type)) {
+            builder.field(ScriptService.SCRIPT_INLINE.getPreferredName(), idOrCode);
+        }
+
+        builder.field(LANG_PARSE_FIELD.getPreferredName(), lang);
+        if (CollectionUtils.isNotEmpty(this.params)) {
+            builder.field(PARAMS_PARSE_FIELD.getPreferredName(), this.params);
+        }
+        if (CollectionUtils.isNotEmpty(this.options)) {
+            builder.field(OPTIONS_PARSE_FIELD.getPreferredName(), this.options);
+        }
+
+        return builder.endObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Script script = (Script) o;
+
+        if (type != script.type) return false;
+        if (lang != null ? !lang.equals(script.lang) : script.lang != null) return false;
+        if (!idOrCode.equals(script.idOrCode)) return false;
+        if (options != null ? !options.equals(script.options) : script.options != null) return false;
+        return params.equals(script.params);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + (lang != null ? lang.hashCode() : 0);
+        result = 31 * result + idOrCode.hashCode();
+        result = 31 * result + (options != null ? options.hashCode() : 0);
+        result = 31 * result + params.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Script{" +
+                "type=" + type +
+                ", lang='" + lang + '\'' +
+                ", idOrCode='" + idOrCode + '\'' +
+                ", options=" + options +
+                ", params=" + params +
+                '}';
+    }
+}

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -25,6 +25,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
@@ -183,6 +184,10 @@ public class ScriptService extends AbstractComponent {
             } else {
                 out.writeVInt(INLINE_VAL); //Default to inline
             }
+        }
+
+        public String lowerCaseName() {
+            return StringUtils.lowerCase(this.name());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
@@ -1,0 +1,101 @@
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author sudeep
+ * @since 15/07/17
+ */
+public abstract class AbstractPipelineAggregationBuilder<PAB extends AbstractPipelineAggregationBuilder<PAB>> implements ToXContent {
+
+    protected final String name;
+    protected final String[] bucketsPaths;
+    protected final String type;
+    protected Map<String, Object> metaData;
+
+    protected AbstractPipelineAggregationBuilder(String name, String type, String[] bucketsPaths) {
+        if (type == null) {
+            throw new IllegalArgumentException("[type] must not be null: [" + name + "]");
+        }
+        if (bucketsPaths == null) {
+            throw new IllegalArgumentException("[bucketsPaths] must not be null: [" + name + "]");
+        }
+        this.type = type;
+        this.name = name;
+        this.bucketsPaths = bucketsPaths;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    /**
+     * Return this aggregation's name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    @SuppressWarnings("unchecked")
+    public PAB setMetaData(Map<String, Object> metaData) {
+        this.metaData = metaData;
+        return (PAB) this;
+    }
+
+    @Override
+    public final XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        if (ToXContentUtils.getVersionFromParams(params).onOrAfter(Version.V_5_0_0)) {
+            builder.startObject(getName());
+
+            if (this.metaData != null) {
+                builder.field("meta", this.metaData);
+            }
+
+            builder.startObject(type);
+            _toXContent(builder, params);
+            builder.endObject();
+            builder.endObject();
+        }
+
+        return builder;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(bucketsPaths), metaData, name, type, _hashCode());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        @SuppressWarnings("unchecked")
+        AbstractPipelineAggregationBuilder<PAB> other = (AbstractPipelineAggregationBuilder<PAB>) obj;
+        if (!Objects.equals(name, other.name))
+            return false;
+        if (!Objects.equals(type, other.type))
+            return false;
+        if (!Objects.deepEquals(bucketsPaths, other.bucketsPaths))
+            return false;
+        if (!Objects.equals(metaData, other.metaData))
+            return false;
+        return _equals(obj);
+    }
+
+    protected abstract int _hashCode();
+
+    protected abstract boolean _equals(Object obj);
+
+    protected abstract XContentBuilder _toXContent(XContentBuilder builder, Params params) throws IOException;
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
+import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentUtils;
@@ -47,6 +48,15 @@ public abstract class AbstractPipelineAggregationBuilder<PAB extends AbstractPip
     @SuppressWarnings("unchecked")
     public PAB setMetaData(Map<String, Object> metaData) {
         this.metaData = metaData;
+        return (PAB) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public PAB addMetadata(String key, Object value) {
+        if (this.metaData == null) {
+            this.metaData = Maps.newHashMap();
+        }
+        this.metaData.put(key, value);
         return (PAB) this;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/pipeline/GapPolicy.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/pipeline/GapPolicy.java
@@ -1,0 +1,44 @@
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * A gap policy determines how "holes" in a set of buckets should be handled.  For example,
+ * a date_histogram might have empty buckets due to no data existing for that time interval.
+ * This can cause problems for operations like a derivative, which relies on a continuous
+ * function.
+ * <p/>
+ * "insert_zeros": empty buckets will be filled with zeros for all metrics
+ * "ignore": empty buckets will simply be ignored
+ *
+ * @author sudeep
+ * @since 15/07/17
+ */
+public enum GapPolicy implements ToXContent {
+    INSERT_ZEROS((byte) 0, "insert_zeros"), SKIP((byte) 1, "skip");
+
+    private final byte id;
+    private final String name;
+
+    GapPolicy(byte id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public byte getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.value(name);
+        return builder;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationBuilders.java
@@ -1,0 +1,22 @@
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.pipeline.bucketselector.BucketSelectorPipelineAggregationBuilder;
+
+import java.util.Map;
+
+/**
+ * @author sudeep
+ * @since 15/07/17
+ */
+public class PipelineAggregationBuilders {
+
+    public static BucketSelectorPipelineAggregationBuilder bucketSelector(String name, Script script,
+                                                                          Map<String, String> bucketsPathsMap) {
+        return new BucketSelectorPipelineAggregationBuilder(name, script, bucketsPathsMap);
+    }
+
+    public static BucketSelectorPipelineAggregationBuilder bucketSelector(String name, Script script, String... bucketPaths) {
+        return new BucketSelectorPipelineAggregationBuilder(name, script, bucketPaths);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketselector/BucketSelectorPipelineAggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketselector/BucketSelectorPipelineAggregationBuilder.java
@@ -1,0 +1,68 @@
+package org.elasticsearch.search.aggregations.pipeline.bucketselector;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.pipeline.AbstractPipelineAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.GapPolicy;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * @author sudeep
+ * @since 15/07/17
+ */
+public class BucketSelectorPipelineAggregationBuilder extends AbstractPipelineAggregationBuilder<BucketSelectorPipelineAggregationBuilder> {
+
+    public static final String TYPE = "bucket_selector";
+
+    public static ParseField BUCKETS_PATH = new ParseField("buckets_path");
+    public static ParseField GAP_POLICY = new ParseField("gap_policy");
+
+
+    private final Map<String, String> bucketsPathsMap;
+    private Script script;
+    private GapPolicy gapPolicy = GapPolicy.SKIP;
+
+    public BucketSelectorPipelineAggregationBuilder(String name, Script script, Map<String, String> bucketsPathsMap) {
+        super(name, TYPE, new TreeMap<>(bucketsPathsMap).values().toArray(new String[bucketsPathsMap.size()]));
+        this.bucketsPathsMap = bucketsPathsMap;
+        this.script = script;
+    }
+
+    public BucketSelectorPipelineAggregationBuilder(String name, Script script, String... bucketsPaths) {
+        this(name, script, convertToBucketsPathMap(bucketsPaths));
+    }
+
+    @Override
+    protected int _hashCode() {
+        return Objects.hash(bucketsPathsMap, script, gapPolicy);
+    }
+
+    @Override
+    protected boolean _equals(Object obj) {
+        BucketSelectorPipelineAggregationBuilder other = (BucketSelectorPipelineAggregationBuilder) obj;
+        return Objects.equals(bucketsPathsMap, other.bucketsPathsMap) && Objects.equals(script, other.script)
+                && Objects.equals(gapPolicy, other.gapPolicy);
+    }
+
+    @Override
+    protected XContentBuilder _toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(GAP_POLICY.getPreferredName(), gapPolicy);
+        builder.field(BUCKETS_PATH.getPreferredName(), bucketsPathsMap);
+        builder.field(Script.SCRIPT_PARSE_FIELD.getPreferredName(), script, params);
+        return builder;
+    }
+
+    private static Map<String, String> convertToBucketsPathMap(String[] bucketsPaths) {
+        Map<String, String> bucketsPathsMap = new HashMap<>();
+        for (int i = 0; i < bucketsPaths.length; i++) {
+            bucketsPathsMap.put("_value" + i, bucketsPaths[i]);
+        }
+        return bucketsPathsMap;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.AbstractPipelineAggregationBuilder;
 import org.elasticsearch.search.facet.FacetBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
@@ -111,6 +112,8 @@ public class SearchSourceBuilder implements ToXContent {
 
     private List<AbstractAggregationBuilder> aggregations;
     private BytesReference aggregationsBinary;
+
+    private List<AbstractPipelineAggregationBuilder> pipelineAggregations;
 
 
     private HighlightBuilder highlightBuilder;
@@ -454,6 +457,14 @@ public class SearchSourceBuilder implements ToXContent {
      */
     public SearchSourceBuilder aggregations(XContentBuilder facets) {
         return aggregations(facets.bytes());
+    }
+
+    public SearchSourceBuilder aggregation(AbstractPipelineAggregationBuilder pipelineAggregationBuilder) {
+        if (pipelineAggregations == null) {
+            pipelineAggregations = Lists.newArrayList();
+        }
+        pipelineAggregations.add(pipelineAggregationBuilder);
+        return this;
     }
 
     /**
@@ -919,11 +930,20 @@ public class SearchSourceBuilder implements ToXContent {
             }
         }
 
-        if (aggregations != null) {
+        if (aggregations != null || pipelineAggregations != null) {
             builder.field("aggregations");
             builder.startObject();
-            for (AbstractAggregationBuilder aggregation : aggregations) {
-                aggregation.toXContent(builder, params);
+
+            if (aggregations != null) {
+                for (AbstractAggregationBuilder aggregation : aggregations) {
+                    aggregation.toXContent(builder, params);
+                }
+            }
+
+            if (pipelineAggregations != null) {
+                for (AbstractPipelineAggregationBuilder pipelineAggregation : pipelineAggregations) {
+                    pipelineAggregation.toXContent(builder, params);
+                }
             }
             builder.endObject();
         }

--- a/src/test/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationBuildersTest.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationBuildersTest.java
@@ -1,0 +1,171 @@
+package org.elasticsearch.search.aggregations.pipeline;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.*;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.support.AbstractClusterAdminClient;
+import org.elasticsearch.client.support.AbstractIndicesAdminClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
+import org.elasticsearch.search.aggregations.metrics.sum.SumBuilder;
+import org.elasticsearch.search.aggregations.pipeline.bucketselector.BucketSelectorPipelineAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author sudeep
+ * @since 16/07/17
+ */
+public class PipelineAggregationBuildersTest {
+
+    private static Version VERSION = Version.V_5_0_0;
+
+    @Test
+    public void print_bucket_selector() {
+        print(getXContentBuilder(bucket_selector(), VERSION));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void fullQuery() throws IOException {
+        TermsBuilder account = AggregationBuilders.terms("account").field("dimensions.ACCOUNT_ID");
+        SumBuilder sum_fans_online = AggregationBuilders.sum("sum_fans_online").field("measurements.FACEBOOK_PAGE_FANS_ONLINE");
+        BucketSelectorPipelineAggregationBuilder sum_fans_filter = bucket_selector();
+        account.subAggregation(sum_fans_online);
+        account.subAggregation(sum_fans_filter);
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(new NoOpClientWithVersion(VERSION)).setSize(0).addAggregation(account);
+        SearchSourceBuilder source = searchRequestBuilder.internalBuilder();
+
+        //XContentBuilder builder = getJsonBuilder();
+        //source.toXContent(builder, ToXContentUtils.createParamsWithTargetClusterVersion(VERSION));
+        System.out.println(source.toString());
+    }
+
+    public BucketSelectorPipelineAggregationBuilder bucket_selector() {
+        Script script = new Script("sumFansOnline > limit", ImmutableMap.of("limit", (Object) 20000));
+        return PipelineAggregationBuilders.bucketSelector("sum_fans_filter", script, ImmutableMap.of("sumFansOnline", "sum_fans_online"));
+    }
+
+    private XContentBuilder getXContentBuilder(ToXContent toXContent, Version esVersion) {
+        try {
+            XContentBuilder xContentBuilder = getJsonBuilder();
+            xContentBuilder.startObject();
+            toXContent.toXContent(xContentBuilder, ToXContentUtils.createParamsWithTargetClusterVersion(esVersion));
+            xContentBuilder.endObject();
+            return xContentBuilder;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void print(XContentBuilder builder) {
+        System.out.println(builder.toString());
+    }
+
+    private XContentBuilder getJsonBuilder() throws IOException {
+        return XContentFactory.jsonBuilder().prettyPrint();
+    }
+
+
+    private static class NoOpClientWithVersion extends NoOpClient {
+        private Version version;
+
+        public NoOpClientWithVersion(Version version) {
+            this.version = version;
+        }
+
+        @Override
+        public Version getClusterVersion() {
+            return version;
+        }
+    }
+
+    private static class NoOpClient extends AbstractClient implements AdminClient {
+
+        @Override
+        public AdminClient admin() {
+            return this;
+        }
+
+        @Override
+        public Settings settings() {
+            return null;
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
+            return null;
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
+            listener.onResponse(null);
+        }
+
+        @Override
+        public ThreadPool threadPool() {
+            return null;
+        }
+
+        @Override
+        public void close() throws ElasticsearchException {
+
+        }
+
+        @Override
+        public ClusterAdminClient cluster() {
+            return new AbstractClusterAdminClient() {
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
+                    return null;
+                }
+
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public ThreadPool threadPool() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public IndicesAdminClient indices() {
+            return new AbstractIndicesAdminClient() {
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
+                    return null;
+                }
+
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public ThreadPool threadPool() {
+                    return null;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
support to make bucket selector pipeline aggs query. For 1.4 clusters…pipeline query is blanked out.